### PR TITLE
edit DAP.md

### DIFF
--- a/DAP.md
+++ b/DAP.md
@@ -6,12 +6,12 @@
         + Pay for HIV-related prescription medications. 
         + Provides assistance in acquiring insurance. 
         + Provides assistance with insurance premium payments and co-pays on HIV-related medications and office services. 
-    - Eligibility depends on the income and insurance of the individuals. 
-* PrEP drug assistance program (PrEP-DAP): 
-    - Provides medications and healthcare to HIV-negative people who are at risk. 
-    - Services pay for certain PrEP and relevant medication costs such as lab and medical visits. 
-    - Eligibility depends on the income and insurance of the individuals but have different cutoff than ADAP.
-* Eligibility of the two programs depends on income and insurance type of the person, but the criteria are different. 
+    - Eligibility depends on the income and insurance of the individuals - namely, in Washington state, the individual must be at or below 400% of the federal poverty level
     - [ADAP eligibility](http://adap.directory/washington#field_eligibility)
+* PrEP drug assistance program (PrEP-DAP): 
+    - For HIV-negative people who are at risk of acquiring HIV
+    - The program covers PrEP copays and relevant non-medication costs such as lab and medical visits.
+    - Gilead's drug assistance programs often cover most of the PrEP drug costs, so PrEP-DAP focuses on non-drug costs
+    - Generally, people are eligible for PrEP-DAP if they are 1) not eligible for Medicaid and 2) at high risk for HIV infection.
     - [PrEP decision tree](https://www.doh.wa.gov/Portals/1/Documents/Pubs/150-082-PayingForPrEPDecisionTree.pdf)
 


### PR DESCRIPTION
I changed these because it seems like ADAP and PDAP have different enough eligibility criteria to not have a shared bullet. I also added some more details about eligibility and services for the two programs